### PR TITLE
Register and unregister channel handlers on main thread

### DIFF
--- a/windows/method_channel_handler.cc
+++ b/windows/method_channel_handler.cc
@@ -46,7 +46,6 @@ void MethodChannelHandler::Terminate() {
     return;
   }
 
-
   std::promise<void> promise;
   task_queue_->Enqueue([&]() {
     registry_->players()->Clear();
@@ -56,12 +55,11 @@ void MethodChannelHandler::Terminate() {
     promise.set_value();
   });
 
-
   promise.get_future().wait();
 
-  // make sure we make a last call to the main thread dispatcher to finish pending work
+  // make sure we make a last call to the main thread dispatcher to finish
+  // pending work
   main_thread_dispatcher_->Terminate();
-
 }
 
 void MethodChannelHandler::HandleMethodCall(
@@ -195,7 +193,8 @@ void MethodChannelHandler::CreatePlayer(
 
         auto player = env->CreatePlayer();
         player->SetEventDelegate(std::make_unique<PlayerBridge>(
-            binary_messenger_, task_queue_, player.get(), main_thread_dispatcher_));
+            binary_messenger_, task_queue_, player.get(),
+            main_thread_dispatcher_));
         auto id = player->id();
         auto texture_id = CreateVideoOutput(player.get());
         registry_->players()->InsertPlayer(id, std::move(player));

--- a/windows/method_channel_handler.h
+++ b/windows/method_channel_handler.h
@@ -4,8 +4,6 @@
 #include <flutter/plugin_registrar_windows.h>
 #include <flutter/standard_method_codec.h>
 
-#include <unordered_map>
-
 #include "base/task_queue.h"
 #include "player_bridge.h"
 #include "resource_registry.h"

--- a/windows/player_bridge.cc
+++ b/windows/player_bridge.cc
@@ -104,14 +104,14 @@ PlayerBridge::PlayerBridge(
     : player_(player),
       task_queue_(std::move(task_queue)),
       main_thread_dispatcher_(main_thread_dispatcher) {
-  auto method_channel_name = string_format("foxglove/%I64i", player_->id());
+  auto method_channel_name = string_format("foxglove/%I64i", player->id());
   method_channel_ =
       std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
           messenger, method_channel_name,
           &flutter::StandardMethodCodec::GetInstance());
 
   const auto event_channel_name =
-      string_format("foxglove/%I64i/events", player_->id());
+      string_format("foxglove/%I64i/events", player->id());
   event_channel_ =
       std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
           messenger, event_channel_name,

--- a/windows/player_bridge.h
+++ b/windows/player_bridge.h
@@ -9,10 +9,10 @@
 #include <memory>
 #include <mutex>
 
+#include "base/single_thread_dispatcher.h"
 #include "base/task_queue.h"
 #include "player.h"
 #include "plugin_state.h"
-#include "base/single_thread_dispatcher.h"
 
 namespace foxglove {
 namespace windows {
@@ -20,8 +20,8 @@ namespace windows {
 class PlayerBridge : public PlayerEventDelegate {
  public:
   PlayerBridge(flutter::BinaryMessenger* messenger,
-               std::shared_ptr<TaskQueue> task_queue,
-                Player* player, std::shared_ptr<SingleThreadDispatcher> main_thread_dispatcher);
+               std::shared_ptr<TaskQueue> task_queue, Player* player,
+               std::shared_ptr<SingleThreadDispatcher> main_thread_dispatcher);
   ~PlayerBridge() override;
 
   void OnMediaChanged(const Media* media, std::unique_ptr<MediaInfo> media_info,
@@ -38,6 +38,7 @@ class PlayerBridge : public PlayerEventDelegate {
   inline bool IsMessengerValid() const { return PluginState::IsValid(); }
 
  private:
+  typedef std::function<void()> VoidCallback;
   Player* player_;
   std::shared_ptr<TaskQueue> task_queue_;
   std::mutex event_sink_mutex_;
@@ -47,6 +48,11 @@ class PlayerBridge : public PlayerEventDelegate {
   std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
       event_channel_;
   std::shared_ptr<SingleThreadDispatcher> main_thread_dispatcher_;
+
+  // Asynchronously registers the channel handlers on the main thread.
+  void RegisterChannelHandlers(VoidCallback callback);
+  // Asynchronously unregisters the channel handlers on the main thread.
+  void UnregisterChannelHandlers(VoidCallback callback);
 
   void HandleMethodCall(
       const flutter::MethodCall<flutter::EncodableValue>& method_call,


### PR DESCRIPTION
Invoke `flutter::EventChannel::SetStreamHandler` and `flutter::MethodChannel::SetMethodCallHandler` on main thread as they're not thread-safe yet.