### PR TITLE
improve error handling.

### DIFF
--- a/core/player.h
+++ b/core/player.h
@@ -24,6 +24,7 @@ class PlayerEventDelegate {
   virtual void OnVolumeChanged(double volume) {}
   virtual void OnMute(bool is_muted) {}
   virtual void OnVideoDimensionsChanged(int32_t width, int32_t height) {}
+  virtual void OnError(int32_t error_code, std::string error_message) {}
 };
 
 class Player : public VideoOutputFactory {
@@ -40,15 +41,15 @@ class Player : public VideoOutputFactory {
 
   virtual std::unique_ptr<Playlist> CreatePlaylist() = 0;
 
-  virtual void Open(std::unique_ptr<Media> media) = 0;
-  virtual void Open(std::unique_ptr<Playlist> playlist) = 0;
-  virtual void Play() = 0;
+  virtual bool Open(std::unique_ptr<Media> media) = 0;
+  virtual bool Open(std::unique_ptr<Playlist> playlist) = 0;
+  virtual bool Play() = 0;
   virtual void Pause() = 0;
   virtual void Stop() = 0;
   virtual void SeekPosition(float position) = 0;
   virtual void SeekTime(int64_t time) = 0;
-  virtual void Next() = 0;
-  virtual void Previous() = 0;
+  virtual bool Next() = 0;
+  virtual bool Previous() = 0;
   virtual void SetRate(float rate) = 0;
   virtual void SetPlaylistMode(PlaylistMode playlist_mode) = 0;
   virtual void SetVolume(double volume) = 0;

--- a/core/player.h
+++ b/core/player.h
@@ -24,7 +24,6 @@ class PlayerEventDelegate {
   virtual void OnVolumeChanged(double volume) {}
   virtual void OnMute(bool is_muted) {}
   virtual void OnVideoDimensionsChanged(int32_t width, int32_t height) {}
-  virtual void OnError(int32_t error_code, std::string error_message) {}
 };
 
 class Player : public VideoOutputFactory {

--- a/core/vlc/vlc_media_list_player.h
+++ b/core/vlc/vlc_media_list_player.h
@@ -25,12 +25,12 @@ class VlcMediaListPlayer
   void SetMediaPlayer(VLC::MediaPlayer& player);
   void SetPlaylist(std::unique_ptr<VlcPlaylist> playlist);
   void SetPlaylistMode(PlaylistMode playlist_mode);
-  void PlayItemAtIndex(int index);
-  void Play();
+  bool PlayItemAtIndex(int index);
+  bool Play();
   void Pause();
   bool StopAsync();
-  void Next();
-  void Previous();
+  bool Next();
+  bool Previous();
 
   VlcPlaylist* playlist() const { return playlist_.get(); }
 
@@ -47,9 +47,9 @@ class VlcMediaListPlayer
 
   void SubscribePlayerEvents();
   void OnMediaPlayerStopping();
-  void PlayItemAtIndexInternal(int index);
-  void PlayItemAtRelativePosition(int pos, bool manual = false);
-  void StartPlayback(int index);
+  bool PlayItemAtIndexInternal(int index);
+  bool PlayItemAtRelativePosition(int pos, bool manual = false);
+  bool StartPlayback(int index);
   void ApplyPendingSeek();
 
   inline libvlc_media_list_t* vlc_media_list() {

--- a/core/vlc/vlc_player.cc
+++ b/core/vlc/vlc_player.cc
@@ -376,9 +376,6 @@ void VlcPlayer::HandleVlcState(PlaybackState state) {
         case PlaybackState::kEnded:
           media_state_.position = 0;
           break;
-        case PlaybackState::kError:
-          media_state_.position = 0;
-          break;
         default:
           break;
       }

--- a/core/vlc/vlc_player.h
+++ b/core/vlc/vlc_player.h
@@ -81,10 +81,10 @@ class VlcPlayer : public Player {
 
   std::unique_ptr<Playlist> CreatePlaylist() override;
 
-  void Open(std::unique_ptr<Media> media) override;
-  void Open(std::unique_ptr<Playlist> playlist) override;
+  bool Open(std::unique_ptr<Media> media) override;
+  bool Open(std::unique_ptr<Playlist> playlist) override;
 
-  void Play() override;
+  bool Play() override;
   void Pause() override;
   void Stop() override;
   void StopSync(
@@ -93,8 +93,8 @@ class VlcPlayer : public Player {
   void SeekTime(int64_t time) override;
   void SetRate(float rate);
 
-  void Next() override;
-  void Previous() override;
+  bool Next() override;
+  bool Previous() override;
 
   void SetPlaylistMode(PlaylistMode playlist_mode) override;
   void SetVolume(double volume) override;
@@ -106,6 +106,7 @@ class VlcPlayer : public Player {
 
  private:
   typedef std::function<void()> VoidCallback;
+  typedef std::function<bool()> BoolCallback;
   VlcMediaState media_state_;
   VlcPlayerState state_;
   std::mutex op_mutex_;
@@ -123,8 +124,8 @@ class VlcPlayer : public Player {
   std::shared_ptr<VlcMediaListPlayer> media_list_player_;
   std::unique_ptr<VLC::MediaPlayerEventManager> player_event_manager_;
 
-  void OpenInternal(std::unique_ptr<VlcPlaylist> playlist, bool is_playlist);
-  void PlayInternal();
+  bool OpenInternal(std::unique_ptr<VlcPlaylist> playlist, bool is_playlist);
+  bool PlayInternal();
   void PauseInternal();
   bool StopInternal();
   void StopSyncInternal(
@@ -132,7 +133,9 @@ class VlcPlayer : public Player {
   void SetPlaylistModeInternal(PlaylistMode playlist_mode);
   void OnPlaylistUpdated();
 
+
   void SafeInvoke(VoidCallback callback);
+  bool SafeInvokeBool(BoolCallback callback);
 
   void SetupEventHandlers();
   void OnPlay();


### PR DESCRIPTION
Adds handling if an error occurs while opening/playing video within vlc (e.g. notifiying dart that there was an problem :)).

Removes a deadlock when trying to terminate the plugin.
The MethodChannelHandler::Terminate method blocks the main thread. At the same time diposing a player tries to invoke a callback on mainthread -> deadlock.
