### PR TITLE
Don't block during channel unregistration

### DIFF
--- a/core/base/closure.h
+++ b/core/base/closure.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <functional>
+
+namespace foxglove {
+typedef std::function<void()> Closure;
+}

--- a/core/base/task_queue.h
+++ b/core/base/task_queue.h
@@ -3,18 +3,18 @@
 #include <atomic>
 #include <condition_variable>
 #include <deque>
-#include <functional>
 #include <mutex>
 #include <optional>
 #include <string>
 #include <thread>
 #include <vector>
 
+#include "closure.h"
+
 namespace foxglove {
 
 class TaskQueue {
  public:
-  typedef std::function<void()> Task;
   TaskQueue(size_t num_threads,
             std::optional<std::string> thread_name = std::nullopt);
   ~TaskQueue();
@@ -33,7 +33,7 @@ class TaskQueue {
     return true;
   }
 
-  bool Enqueue(Task task) {
+  bool Enqueue(Closure task) {
     if (terminated_) {
       return false;
     }
@@ -50,7 +50,7 @@ class TaskQueue {
   std::vector<std::thread> workers_;
   std::mutex task_pending_mutex_;
   std::condition_variable task_pending_cv_;
-  std::deque<Task> pending_tasks_;
+  std::deque<Closure> pending_tasks_;
 
   void Run();
 };

--- a/core/player.h
+++ b/core/player.h
@@ -32,6 +32,7 @@ class Player : public VideoOutputFactory {
 
   virtual void SetEventDelegate(
       std::unique_ptr<PlayerEventDelegate> event_delegate) = 0;
+  virtual PlayerEventDelegate* event_delegate() const = 0;
 
   int64_t id() const { return reinterpret_cast<int64_t>(this); }
 

--- a/core/vlc/vlc_player.h
+++ b/core/vlc/vlc_player.h
@@ -3,6 +3,7 @@
 #include <condition_variable>
 #include <mutex>
 
+#include "base/thread_checker.h"
 #include "events.h"
 #include "player.h"
 #include "vlc/vlc_environment.h"
@@ -64,6 +65,8 @@ class VlcPlayer : public Player {
     event_delegate_ = std::move(event_delegate);
   }
 
+  PlayerEventDelegate* event_delegate() const { return event_delegate_.get(); }
+
   // |VideoOutputFactory|
   std::unique_ptr<VideoOutput> CreatePixelBufferOutput(
       std::unique_ptr<PixelBufferOutputDelegate> output_delegate,
@@ -107,6 +110,8 @@ class VlcPlayer : public Player {
  private:
   typedef std::function<void()> VoidCallback;
   typedef std::function<bool()> BoolCallback;
+
+  ThreadChecker thread_checker_;
   VlcMediaState media_state_;
   VlcPlayerState state_;
   std::mutex op_mutex_;
@@ -132,7 +137,6 @@ class VlcPlayer : public Player {
       std::optional<std::chrono::milliseconds> timeout = std::nullopt);
   void SetPlaylistModeInternal(PlaylistMode playlist_mode);
   void OnPlaylistUpdated();
-
 
   void SafeInvoke(VoidCallback callback);
   bool SafeInvokeBool(BoolCallback callback);

--- a/windows/method_channel_handler.h
+++ b/windows/method_channel_handler.h
@@ -50,6 +50,12 @@ class MethodChannelHandler {
   std::shared_ptr<MainThreadDispatcher> main_thread_dispatcher_;
 
   int64_t CreateVideoOutput(Player* player);
+
+  void DestroyPlayers();
+
+  // Asynchronously unregisters channel handlers.
+  // Returns true if the callback, if provided, is guaranteed to be invoked.
+  bool UnregisterChannelHandlers(Player* player, Closure callback = nullptr);
 };
 }  // namespace windows
 }  // namespace foxglove

--- a/windows/player_bridge.h
+++ b/windows/player_bridge.h
@@ -24,6 +24,11 @@ class PlayerBridge : public PlayerEventDelegate {
                std::shared_ptr<MainThreadDispatcher> main_thread_dispatcher);
   ~PlayerBridge() override;
 
+  // Asynchronously registers the channel handlers on the main thread.
+  void RegisterChannelHandlers(Closure callback);
+  // Asynchronously unregisters the channel handlers on the main thread.
+  bool UnregisterChannelHandlers(Closure callback);
+
   void OnMediaChanged(const Media* media, std::unique_ptr<MediaInfo> media_info,
                       size_t index) override;
   void OnPlaybackStateChanged(PlaybackState playback_state,
@@ -38,7 +43,6 @@ class PlayerBridge : public PlayerEventDelegate {
   inline bool IsMessengerValid() const { return PluginState::IsValid(); }
 
  private:
-  typedef std::function<void()> VoidCallback;
   Player* player_;
   std::shared_ptr<TaskQueue> task_queue_;
   std::mutex event_sink_mutex_;
@@ -48,11 +52,6 @@ class PlayerBridge : public PlayerEventDelegate {
   std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
       event_channel_;
   std::shared_ptr<MainThreadDispatcher> main_thread_dispatcher_;
-
-  // Asynchronously registers the channel handlers on the main thread.
-  void RegisterChannelHandlers(VoidCallback callback);
-  // Asynchronously unregisters the channel handlers on the main thread.
-  void UnregisterChannelHandlers(VoidCallback callback);
 
   void HandleMethodCall(
       const flutter::MethodCall<flutter::EncodableValue>& method_call,
@@ -65,6 +64,8 @@ class PlayerBridge : public PlayerEventDelegate {
   void Enqueue(std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>>
                    method_result,
                std::function<void(MethodResult result)> handler);
+  void SetEventSink(
+      std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> event_sink);
 };
 
 }  // namespace windows

--- a/windows/resource_registry.cc
+++ b/windows/resource_registry.cc
@@ -70,6 +70,22 @@ std::unique_ptr<Player> PlayerRegistry::RemovePlayer(int64_t player_id) {
   return player;
 }
 
+void PlayerRegistry::Visit(VisitPlayerCallback visitor) {
+  std::lock_guard<std::mutex> lock(map_mutex_);
+  for (const auto& kvp : items_) {
+    visitor(kvp.second.get());
+  }
+}
+
+void PlayerRegistry::EraseAll(VisitPlayerCallback visitor) {
+  std::lock_guard<std::mutex> lock(map_mutex_);
+  auto it = items_.begin();
+  while (it != items_.end()) {
+    visitor(it->second.get());
+    it = items_.erase(it);
+  }
+}
+
 size_t PlayerRegistry::Count() {
   std::lock_guard<std::mutex> lock(map_mutex_);
   return items_.size();

--- a/windows/resource_registry.h
+++ b/windows/resource_registry.h
@@ -26,10 +26,14 @@ class EnvironmentRegistry {
 
 class PlayerRegistry {
  public:
+  typedef std::function<void(Player* player)> VisitPlayerCallback;
+
   PlayerRegistry();
 
   void InsertPlayer(int64_t player_id, std::unique_ptr<Player> player);
   std::unique_ptr<Player> RemovePlayer(int64_t player_id);
+  void Visit(VisitPlayerCallback visitor);
+  void EraseAll(VisitPlayerCallback visitor);
   void Clear();
   size_t Count();
 


### PR DESCRIPTION
Don't implicitly unregister channel handlers in PlayerBridge destructor. Instead, add explicit methods which accept a callback.