### PR TITLE
Fix PlayerBridge crash

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(${PLUGIN_NAME} SHARED
   "message_window.cc"
   "method_channel_handler.cc"
   "player_bridge.cc"
+  "player_channels.cc"
   "resource_registry.cc"
   "video/video_outlet_d3d.cc"
   "video/texture_registry.cc"

--- a/windows/player_channels.cc
+++ b/windows/player_channels.cc
@@ -1,0 +1,125 @@
+
+#include "player_channels.h"
+
+#include <flutter/event_stream_handler_functions.h>
+
+#include "player_events.h"
+
+namespace foxglove {
+namespace windows {
+
+namespace {
+
+template <typename... Args>
+std::string string_format(const std::string& format, Args... args) {
+  size_t size = snprintf(nullptr, 0, format.c_str(), args...) + 1;
+  if (size <= 0) {
+    throw std::runtime_error("Error during formatting.");
+  }
+  std::unique_ptr<char[]> buf(new char[size]);
+  snprintf(buf.get(), size, format.c_str(), args...);
+  return std::string(buf.get(), buf.get() + size - 1);
+}
+
+}  // namespace
+
+PlayerChannels::PlayerChannels(
+    flutter::BinaryMessenger* messenger, int64_t player_id,
+    std::shared_ptr<MainThreadDispatcher> main_thread_dispatcher)
+    : main_thread_dispatcher_(std::move(main_thread_dispatcher)) {
+  auto method_channel_name = string_format("foxglove/%I64i", player_id);
+  method_channel_ =
+      std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+          messenger, method_channel_name,
+          &flutter::StandardMethodCodec::GetInstance());
+
+  const auto event_channel_name =
+      string_format("foxglove/%I64i/events", player_id);
+  event_channel_ =
+      std::make_unique<flutter::EventChannel<flutter::EncodableValue>>(
+          messenger, event_channel_name,
+          &flutter::StandardMethodCodec::GetInstance());
+}
+
+void PlayerChannels::Register(
+    flutter::MethodCallHandler<flutter::EncodableValue> method_call_handler,
+    Closure callback) {
+  main_thread_dispatcher_->Dispatch([self = shared_from_this(),
+                                     method_call_handler =
+                                         std::move(method_call_handler),
+                                     callback = std::move(callback)]() {
+    assert(IsMessengerValid());
+    self->method_channel_->SetMethodCallHandler(method_call_handler);
+
+    auto stream_handler = std::make_unique<
+        flutter::StreamHandlerFunctions<flutter::EncodableValue>>(
+        [self](const flutter::EncodableValue* arguments,
+               std::unique_ptr<flutter::EventSink<flutter::EncodableValue>>&&
+                   events) {
+          self->SetEventSink(std::move(events));
+          return nullptr;
+        },
+        [self](const flutter::EncodableValue* arguments) {
+          self->SetEventSink(nullptr);
+          return nullptr;
+        });
+    self->event_channel_->SetStreamHandler(std::move(stream_handler));
+
+    if (callback) {
+      callback();
+    }
+  });
+}
+
+bool PlayerChannels::Unregister(Closure callback) {
+  SetEventSink(nullptr);
+
+  if (!IsMessengerValid()) {
+    return false;
+  }
+
+  main_thread_dispatcher_->Dispatch(
+      [self = shared_from_this(), callback = std::move(callback)]() {
+        // Channel handlers must not be unset during plugin destruction
+        // See https://github.com/flutter/flutter/issues/118611
+        if (IsMessengerValid()) {
+          self->method_channel_->SetMethodCallHandler(nullptr);
+          self->event_channel_->SetStreamHandler(nullptr);
+        }
+
+        if (callback) {
+          callback();
+        }
+      });
+
+  return true;
+}
+
+void PlayerChannels::EmitEvent(const flutter::EncodableValue& event) const {
+  auto weak_self = weak_from_this();
+  main_thread_dispatcher_->Dispatch([this, weak_self, event] {
+    if (!IsMessengerValid()) {
+      return;
+    }
+
+    if (auto self = weak_self.lock()) {
+      const std::lock_guard lock(event_sink_mutex_);
+      if (event_sink_) {
+        event_sink_->Success(event);
+      }
+    }
+  });
+}
+
+void PlayerChannels::SetEventSink(
+    std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> event_sink) {
+  const std::lock_guard lock(event_sink_mutex_);
+  event_sink_ = std::move(event_sink);
+  if (event_sink_) {
+    event_sink_->Success(flutter::EncodableValue(
+        flutter::EncodableMap{{kEventType, Events::kInitialized}}));
+  }
+}
+
+}  // namespace windows
+}  // namespace foxglove

--- a/windows/player_channels.h
+++ b/windows/player_channels.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <flutter/event_channel.h>
+#include <flutter/method_channel.h>
+#include <flutter/standard_method_codec.h>
+
+#include <memory>
+#include <mutex>
+
+#include "base/closure.h"
+#include "main_thread_dispatcher.h"
+#include "plugin_state.h"
+
+namespace foxglove {
+namespace windows {
+
+class PlayerChannels : public std::enable_shared_from_this<PlayerChannels> {
+ public:
+  PlayerChannels(flutter::BinaryMessenger* messenger, int64_t player_id,
+                 std::shared_ptr<MainThreadDispatcher> main_thread_dispatcher);
+  void Register(flutter::MethodCallHandler<flutter::EncodableValue> handler,
+                Closure callback);
+  bool Unregister(Closure callback);
+  void EmitEvent(const flutter::EncodableValue& event) const;
+
+ private:
+  mutable std::mutex event_sink_mutex_;
+  std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> event_sink_;
+  std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
+      event_channel_;
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
+      method_channel_;
+  std::shared_ptr<MainThreadDispatcher> main_thread_dispatcher_;
+
+  inline static bool IsMessengerValid() { return PluginState::IsValid(); }
+  void SetEventSink(
+      std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> event_sink);
+};
+
+}  // namespace windows
+}  // namespace foxglove

--- a/windows/player_events.h
+++ b/windows/player_events.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+
+namespace foxglove {
+namespace windows {
+
+constexpr const char kEventType[] = "type";
+constexpr const char kEventValue[] = "value";
+
+enum Events : int32_t {
+  kNone,
+  kInitialized,
+  kPositionChanged,
+  kPlaybackStateChanged,
+  kMediaChanged,
+  kRateChanged,
+  kVolumeChanged,
+  kMuteChanged,
+  kVideoDimensionsChanged,
+  kIsSeekableChanged
+};
+
+}  // namespace windows
+}  // namespace foxglove


### PR DESCRIPTION
Fixes a potential access violation in `PlayerBridge` due to accessing a potentially dangling `PlayerBridge` instance from the main thread task runner.
This factors out some parts of `PlayerBridge` to `PlayerChannels` (which encapsulates a player's method channel and event channel) and introduces shared ownership to `PlayerChannels` which allows the main thread task runner callbacks to keep a strong reference to `PlayerChannels`.